### PR TITLE
Import clean ups from main repository pending PRs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ https://<kubernetes-master>/ui/
 which redirects to:
 
 ```
-https://<kubernetes-master>/static/app/
+https://<kubernetes-master>/api/v1/proxy/namespaces/kube-system/services/kube-ui/
 ```
 
 ## Configuration

--- a/master/gulpfile.js
+++ b/master/gulpfile.js
@@ -73,7 +73,10 @@ var source = {
       'shared/js/modules/controllers/*.js',
       'shared/js/modules/directives/*.js',
       'shared/js/modules/services/*.js',
-      'components/**/js/**/*.js'
+      'components/**/js/modules/*.js',
+      'components/**/js/modules/controllers/*.js',
+      'components/**/js/modules/directives/*.js',
+      'components/**/js/modules/services/*.js'
     ],
     dest: {
       name: 'app.js', 
@@ -290,7 +293,7 @@ gulp.task('styles:app', function() {
 gulp.task('config', gulpsync.sync(['config:base', 'config:copy']));
 
 gulp.task('config:base', function() {
-  return stringSrc('generated-config.js', 'angular.module("kubernetesApp.config", [])' +
+  return stringSrc('generated-config.js', 'angular.module("kubernetesApp.config")' +
                                               '\n' +
                                               '.constant("ENV", {})').pipe(gulp.dest(source.config.dest));
 });
@@ -374,11 +377,13 @@ gulp.task('content:html:views', function() {
 gulp.task('watch', function() {
   livereload.listen();
 
-  gulp.watch(source.html.watch, ['content:html']);
-  gulp.watch(source.scripts.watch, ['scripts:app']);
-  gulp.watch(source.styles.app.watch, ['styles:app']);
-  gulp.watch(source.components.watch, ['copy:components']);
-  gulp.watch(source.assets.watch, ['copy:shared-assets']);
+  gulp.watch([
+    source.assets.watch,
+    source.components.watch, 
+    source.html.watch, 
+    source.scripts.watch, 
+    source.styles.app.watch
+    ], ['compile']);
 
   gulp.watch(['../app/**'])
       .on('change', function(event) {

--- a/master/karma.conf.js
+++ b/master/karma.conf.js
@@ -14,11 +14,10 @@ module.exports = function(config) {
       '../third_party/ui/bower_components/lodash/dist/lodash.js',
       'app/assets/js/app.js',
       'app/assets/js/base.js',
-      'app/shared/**/*.js',
       'app/vendor/**/*.js',
-      'master/shared/**/*.js',
       'master/test/**/*.js',
-      'master/components/**/test/**/*.js'
+      'master/components/**/test/**/*.js',
+      'app/**/img/**/*.*'
     ],
 
     autoWatch: true,

--- a/master/shared/config/development.example.json
+++ b/master/shared/config/development.example.json
@@ -1,6 +1,8 @@
 {
   "k8sApiServer": "/api/v1",
-  "k8sDataServer": "",
+  "k8sDataService": "/cluster-insight",
+  "k8sDataServicePortName": ":cluster-insight",
+  "k8sDataServiceEndpoint": "/cluster",
   "k8sDataPollMinIntervalSec": 10,
   "k8sDataPollMaxIntervalSec": 120,
   "k8sDataPollErrorThreshold": 5,

--- a/master/shared/config/generated-config.js
+++ b/master/shared/config/generated-config.js
@@ -3,7 +3,9 @@ angular.module("kubernetesApp.config", [])
 .constant("ENV", {
 	"/": {
 		"k8sApiServer": "/api/v1",
-		"k8sDataServer": "",
+		"k8sDataService": "/cluster-insight",
+		"k8sDataServicePortName": ":cluster-insight",
+		"k8sDataServiceEndpoint": "/cluster",
 		"k8sDataPollMinIntervalSec": 10,
 		"k8sDataPollMaxIntervalSec": 120,
 		"k8sDataPollErrorThreshold": 5,

--- a/master/shared/config/production.json
+++ b/master/shared/config/production.json
@@ -1,6 +1,8 @@
 {
   "k8sApiServer": "/api/v1",
-  "k8sDataServer": "",
+  "k8sDataService": "/cluster-insight",
+  "k8sDataServicePortName": ":cluster-insight",
+  "k8sDataServiceEndpoint": "/cluster",
   "k8sDataPollMinIntervalSec": 10,
   "k8sDataPollMaxIntervalSec": 120,
   "k8sDataPollErrorThreshold": 5,

--- a/master/shared/js/modules/services/pollK8sData.js
+++ b/master/shared/js/modules/services/pollK8sData.js
@@ -9,20 +9,52 @@
     var useSampleData = false;
     this.setUseSampleData = function(value) { useSampleData = value; };
 
-    var sampleDataFiles = ["shared/assets/sampleData1.json"];
+    var sampleDataFiles = [];
     this.setSampleDataFiles = function(value) { sampleDataFiles = value; };
 
-    var dataServer = "http://localhost:5555/cluster";
-    this.setDataServer = function(value) { dataServer = value; };
+    var proxyVerb = "/api/v1/proxy/namespaces/default/services";
 
-    var pollMinIntervalSec = 10;
+    var dataService = undefined;
+    var dataServiceDefault = "/cluster-insight";
+
+    this.setDataService = function(value) { dataService = value; };
+    this.getDataService = function() { return dataService || dataServiceDefault; }
+    var getDataService = this.getDataService;
+
+    var dataServicePortName = undefined;
+    var dataServicePortNameDefault = ":cluster-insight";
+
+    this.setDataServicePortName = function(value) { dataServicePortName = value; };
+    this.getDataServicePortName = function() { return dataServicePortName || dataServicePortNameDefault; }
+    var getDataServicePortName = this.getDataServicePortName;
+
+    var dataServiceEndpoint = undefined;
+    var dataServiceEndpointDefault = "/cluster";
+
+    this.setDataServiceEndpoint = function(value) { dataServiceEndpoint = value; };
+    this.getDataServiceEndpoint = function() { return dataServiceEndpoint || dataServiceEndpointDefault; }
+    var getDataServiceEndpoint = this.getDataServiceEndpoint;
+
+    var pollMinIntervalSec = undefined;
+    var pollMinIntervalSecDefault = 10;
+
     this.setPollMinIntervalSec = function(value) { pollMinIntervalSec = value; };
+    this.getPollMinIntervalSec = function() { return pollMinIntervalSec || pollMinIntervalSecDefault; };
+    var getPollMinIntervalSec = this.getPollMinIntervalSec;
 
-    var pollMaxIntervalSec = 120;
+    var pollMaxIntervalSec = undefined;
+    var pollMaxIntervalSecDefault = 120;
+
     this.setPollMaxIntervalSec = function(value) { pollMaxIntervalSec = value; };
+    this.getPollMaxIntervalSec = function() { return pollMaxIntervalSec || pollMaxIntervalSecDefault; };
+    var getPollMaxIntervalSec = this.getPollMaxIntervalSec;
 
-    var pollErrorThreshold = 5;
+    var pollErrorThreshold = undefined;
+    var pollErrorThresholdDefault = 5;
+
     this.setPollErrorThreshold = function(value) { pollErrorThreshold = value; };
+    this.getPollErrorThreshold = function() { return pollErrorThreshold || pollErrorThresholdDefault; };
+    var getPollErrorThreshold = this.getPollErrorThreshold;
 
     this.$get = function($http, $timeout) {
       // Now the sequenceNumber will be used for debugging and verification purposes.
@@ -35,12 +67,12 @@
       var promise = undefined;
 
       // Implement fibonacci back off when the service is down.
-      var pollInterval = pollMinIntervalSec;
+      var pollInterval = getPollMinIntervalSec();
       var pollIncrement = pollInterval;
 
       // Reset polling interval.
       var resetCounters = function() {
-        pollInterval = pollMinIntervalSec;
+        pollInterval = getPollMinIntervalSec();
         pollIncrement = pollInterval;
       };
 
@@ -50,8 +82,8 @@
         pollingError++;
 
         // TODO: maybe display an error in the UI to the end user.
-        if (pollingError % pollErrorThreshold === 0) {
-          console.log("Error: " + pollingError + " consecutive polling errors for " + dataServer + ".");
+        if (pollingError % getPollErrorThreshold() === 0) {
+          console.log("Error: " + pollingError + " consecutive polling errors for " + getDataService() + ".");
         }
 
         // Bump the polling interval.
@@ -60,7 +92,7 @@
         pollInterval += oldIncrement;
 
         // Reset when limit reached.
-        if (pollInterval > pollMaxIntervalSec) {
+        if (pollInterval > getPollMaxIntervalSec()) {
           resetCounters();
         }
       };
@@ -68,12 +100,19 @@
       var updateModel = function(newModel) {
         var dedupe = function(dataModel) {
           if (dataModel.resources) {
-            dataModel.resources = _.uniq(dataModel.resources, function(resource) { return resource.id; });
+            var compareResources = function(resource) { return resource.id; };
+            dataModel.resources = _.chain(dataModel.resources)
+              .sortBy(compareResources)
+              .uniq(true, compareResources)
+              .value();
           }
 
           if (dataModel.relations) {
-            dataModel.relations =
-                _.uniq(dataModel.relations, function(relation) { return relation.source + relation.target; });
+            var compareRelations = function(relation) { return relation.source + relation.target; };
+            dataModel.relations = _.chain(dataModel.relations)
+              .sortBy(compareRelations)
+              .uniq(true, compareRelations)
+              .value();
           }
         };
 
@@ -105,26 +144,32 @@
         return result;
       };
 
-      var pollOnce = function(scope, repeat) {
-        var dataSource = (k8sdatamodel.useSampleData) ? getSampleDataFile() : dataServer;
-        $.getJSON(dataSource)
-            .done(function(newModel, jqxhr, textStatus) {
-              if (newModel && newModel.success) {
-                delete newModel.success;    // Remove success indicator.
-                delete newModel.timestamp;  // Remove changing timestamp.
-                updateModel(newModel);
-                scope.$apply();
-                promise = repeat ? $timeout(function() { pollOnce(scope, true); }, pollInterval * 1000) : undefined;
-                return;
-              }
+      var getDataServiceURL = function() {
+        return proxyVerb + getDataService() + getDataServicePortName() + getDataServiceEndpoint();
+      };
 
-              bumpCounters();
-              promise = repeat ? $timeout(function() { pollOnce(scope, true); }, pollInterval * 1000) : undefined;
-            })
-            .fail(function(jqxhr, textStatus, error) {
-              bumpCounters();
-              promise = repeat ? $timeout(function() { pollOnce(scope, true); }, pollInterval * 1000) : undefined;
-            });
+      var pollOnce = function(scope, repeat) {
+        var dataSource = (k8sdatamodel.useSampleData) ? getSampleDataFile() : getDataServiceURL();
+        if (dataSource) {
+          $.getJSON(dataSource)
+              .done(function(newModel, jqxhr, textStatus) {
+                if (newModel && newModel.success) {
+                  delete newModel.success;
+                  delete newModel.timestamp;  // Remove changing timestamp.
+                  updateModel(newModel);
+                  scope.$apply();
+                  promise = repeat ? $timeout(function() { pollOnce(scope, true); }, pollInterval * 1000) : undefined;
+                  return;
+                }
+
+                bumpCounters();
+                promise = repeat ? $timeout(function() { pollOnce(scope, true); }, pollInterval * 1000) : undefined;
+              })
+              .fail(function(jqxhr, textStatus, error) {
+                bumpCounters();
+                promise = repeat ? $timeout(function() { pollOnce(scope, true); }, pollInterval * 1000) : undefined;
+              });
+        }
       };
 
       var isPolling = function() { return promise ? true : false; };
@@ -149,7 +194,7 @@
       };
 
       var refresh = function(scope) {
-        stop(scope);
+        stop();
         resetCounters();
         k8sdatamodel.data = undefined;
         pollOnce(scope, false);
@@ -169,8 +214,14 @@
       .provider("pollK8sDataService", ["lodash", pollK8sDataServiceProvider])
       .config(function(pollK8sDataServiceProvider, ENV) {
         if (ENV && ENV['/']) {
-          if (ENV['/']['k8sDataServer']) {
-            pollK8sDataServiceProvider.setDataServer(ENV['/']['k8sDataServer']);
+          if (ENV['/']['k8sDataService']) {
+            pollK8sDataServiceProvider.setDataService(ENV['/']['k8sDataService']);
+          }
+          if (ENV['/']['k8sDataServicePortName']) {
+            pollK8sDataServiceProvider.setDataServicePortName(ENV['/']['k8sDataServicePortName']);
+          }
+          if (ENV['/']['k8sDataServiceEndpoint']) {
+            pollK8sDataServiceProvider.setDataServiceEndpoint(ENV['/']['k8sDataServiceEndpoint']);
           }
           if (ENV['/']['k8sDataPollIntervalMinSec']) {
             pollK8sDataServiceProvider.setPollIntervalSec(ENV['/']['k8sDataPollIntervalMinSec']);


### PR DESCRIPTION
This PR does the following:
- Updates pollK8sDataServiceProvider to reflect the changes made to deploy cluster-insight as a Kubernetes service.
- Cleans up a few remaining race conditions and redundant angular module dependency generation in gulpfile.js.
- Removes unused paths from karma.conf.js and adds paths for images, to include them in the files served during tests.
- Imports the documentation change for the redirect path to the kube-ui service by timstclair in the main repository.
