### PR TITLE
chore(dashboard): remove pod visualizer

### DIFF
--- a/master/components/dashboard/manifest.json
+++ b/master/components/dashboard/manifest.json
@@ -12,11 +12,6 @@
       "templateUrl": "components/dashboard/views/listPods.html"
     },
     {
-      "description": "Pod Visualizer",
-      "url": "/visualpods",
-      "templateUrl": "components/dashboard/views/listPodsVisualizer.html"
-    },
-    {
       "description": "Services",
       "url": "/services",
       "templateUrl": "components/dashboard/views/listServices.html"


### PR DESCRIPTION
Pod Visualizer was an early prototype which was abandoned in favor of
the pod listing page.

Closes #25
