### PR TITLE
Show all namespaces by default

### DIFF
--- a/master/components/dashboard/js/modules/controllers/listPodsController.js
+++ b/master/components/dashboard/js/modules/controllers/listPodsController.js
@@ -21,6 +21,7 @@ app.controller('ListPodsCtrl', [
       {name: 'Status', field: 'status'},
       {name: 'Containers', field: 'containers'},
       {name: 'Images', field: 'images'},
+      {name: 'Namespace', field: 'namespace'},
       {name: 'Host', field: 'host'},
       {name: 'Labels', field: 'labels'}
     ];
@@ -37,7 +38,7 @@ app.controller('ListPodsCtrl', [
     $scope.sortable = ['pod', 'ip', 'status'];
     $scope.count = 10;
 
-    $scope.go = function(data) { $location.path('/dashboard/pods/' + data.pod); };
+    $scope.go = function(data) { $location.path('/dashboard/pods/' + data.namespace + '/' + data.pod); };
 
     var orderedPodNames = [];
 
@@ -93,7 +94,8 @@ app.controller('ListPodsCtrl', [
             images: _fixComma(_images),
             host: pod.spec.host,
             labels: _fixComma(_labels) + ':' + _fixComma(_uses),
-            status: pod.status.phase
+            status: pod.status.phase,
+            namespace: pod.metadata.namespace
           });
 
         });

--- a/master/components/dashboard/js/modules/controllers/listReplicationControllersController.js
+++ b/master/components/dashboard/js/modules/controllers/listReplicationControllersController.js
@@ -22,7 +22,8 @@ app.controller('ListReplicationControllersCtrl', [
       {name: 'Containers', field: 'containers'},
       {name: 'Images', field: 'images'},
       {name: 'Selector', field: 'selector'},
-      {name: 'Replicas', field: 'replicas'}
+      {name: 'Replicas', field: 'replicas'},
+      {name: 'Namespace', field: 'namespace'}
     ];
 
     $scope.custom = {
@@ -30,13 +31,14 @@ app.controller('ListReplicationControllersCtrl', [
       containers: 'grey',
       images: 'grey',
       selector: 'grey',
-      replicas: 'grey'
+      replicas: 'grey',
+      namespace: 'grey'
     };
-    $scope.sortable = ['controller', 'containers', 'images'];
+    $scope.sortable = ['controller', 'containers', 'images', 'namespace'];
     $scope.thumbs = 'thumb';
     $scope.count = 10;
 
-    $scope.go = function(data) { $location.path('/dashboard/replicationcontrollers/' + data.controller); };
+    $scope.go = function(data) { $location.path('/dashboard/replicationcontrollers/' + data.namespace + '/' + data.controller); };
 
     function handleError(data, status, headers, config) {
       console.log("Error (" + status + "): " + data);
@@ -81,7 +83,8 @@ app.controller('ListReplicationControllersCtrl', [
             containers: _name,
             images: _image,
             selector: _selectors,
-            replicas: replicationController.status.replicas
+            replicas: replicationController.status.replicas,
+            namespace: replicationController.metadata.namespace
           });
 
         });

--- a/master/components/dashboard/js/modules/controllers/listServicesController.js
+++ b/master/components/dashboard/js/modules/controllers/listServicesController.js
@@ -19,7 +19,7 @@ app.controller('ListServicesCtrl', [
       {name: 'Labels', field: 'labels'},
       {name: 'Selector', field: 'selector'},
       {name: 'IP', field: 'ip'},
-      {name: 'Ports', field: 'port'}
+      {name: 'Namespace', field: 'namespace'}
     ];
 
     $scope.custom = {
@@ -27,12 +27,13 @@ app.controller('ListServicesCtrl', [
       ip: 'grey',
       selector: 'grey',
       port: 'grey',
-      labels: 'grey'
+      labels: 'grey',
+      namespace: 'grey'
     };
-    $scope.sortable = ['name', 'ip', 'port'];
+    $scope.sortable = ['name', 'ip', 'port', 'namespace'];
     $scope.count = 10;
 
-    $scope.go = function(data) { $location.path('/dashboard/services/' + data.name); };
+    $scope.go = function(data) { $location.path('/dashboard/services/' + data.namespace + '/' + data.name); };
 
     $scope.content = [];
 
@@ -96,7 +97,8 @@ app.controller('ListServicesCtrl', [
               ip: service.spec.portalIP,
               port: _ports,
               selector: _selectors,
-              labels: _labels
+              labels: _labels,
+              namespace: service.metadata.namespace
             });
           });
         }

--- a/master/components/dashboard/js/modules/controllers/podController.js
+++ b/master/components/dashboard/js/modules/controllers/podController.js
@@ -20,14 +20,14 @@ app.controller('PodCtrl', [
       $scope_.loading = false;
     };
 
-    $scope.handlePod = function(podId) {
+    $scope.handlePod = function(podId, namespaceId) {
       $scope.loading = true;
-      k8sApi.getPods(podId).success(angular.bind(this, function(data) {
+      k8sApi.getPods(podId, namespaceId).success(angular.bind(this, function(data) {
         $scope.pod = data;
         $scope.loading = false;
       })).error($scope.handleError);
     };
 
-    $scope.handlePod($routeParams.podId);
+    $scope.handlePod($routeParams.podId, $routeParams.namespaceId);
   }
 ]);

--- a/master/components/dashboard/js/modules/controllers/replicationController.js
+++ b/master/components/dashboard/js/modules/controllers/replicationController.js
@@ -2,19 +2,18 @@
  * Module: Replication
  * Visualizer for replication controllers
  =========================================================*/
-(function() {
-	function Replicationcontroller() {
+	function ReplicationController() {
 	}
 
-	Replicationcontroller.prototype.getdata = function(dataid) {
+	ReplicationController.prototype.getData = function(dataid, namespaceId) {
 		this.scope.loading = true;
-		this.k8sapi.getreplicationcontrollers(dataid).success(angular.bind(this, function(data) {
-			this.scope.replicationcontroller = data;
+		this.k8sApi.getReplicationControllers(dataid, namespaceId).success(angular.bind(this, function(data) {
+			this.scope.replicationController = data;
 			this.scope.loading = false;
 		})).error(angular.bind(this, this.handleError));
 	};
 
-	Replicationcontroller.prototype.handleError = function(data, status, headers, config) {
+	ReplicationController.prototype.handleError = function(data, status, headers, config) {
 		console.log("error (" + status + "): " + data);
 		this.scope.loading = false;
 	};
@@ -27,11 +26,10 @@
 			$scope.controller = new ReplicationController();
 			$scope.controller.k8sApi = k8sApi;
 			$scope.controller.scope = $scope;
-			$scope.controller.getData($routeParams.replicationControllerId);
+			$scope.controller.getData($routeParams.replicationControllerId, $routeParams.namespaceId);
 
 			$scope.doTheBack = function() { window.history.back(); };
 			$scope.getSelectorUrlFragment = function(sel){ return _.map(sel, function(v, k) { return k + '=' + v }).join(','); };
 
 		}
 	]);
-})();

--- a/master/components/dashboard/js/modules/controllers/serviceController.js
+++ b/master/components/dashboard/js/modules/controllers/serviceController.js
@@ -6,9 +6,10 @@
 function ServiceController() {
 }
 
-ServiceController.prototype.getData = function(dataId) {
+ServiceController.prototype.getData = function(dataId, namespaceId) {
   this.scope.loading = true;
-  this.k8sApi.getServices(dataId).success(angular.bind(this, function(data) {
+
+  this.k8sApi.getServices(dataId, namespaceId).success(angular.bind(this, function(data) {
     this.scope.service = data;
     this.scope.loading = false;
   })).error(angular.bind(this, this.handleError));
@@ -25,10 +26,12 @@ app.controller('ServiceCtrl', [
   'k8sApi',
   '$location',
   function($scope, $routeParams, k8sApi, $location) {
+
+
     $scope.controller = new ServiceController();
     $scope.controller.k8sApi = k8sApi;
     $scope.controller.scope = $scope;
-    $scope.controller.getData($routeParams.serviceId);
+    $scope.controller.getData($routeParams.serviceId, $routeParams.namespaceId);
 
     $scope.doTheBack = function() { window.history.back(); };
     $scope.go = function(d) { $location.path('/dashboard/services/' + d.metadata.name); }

--- a/master/components/dashboard/manifest.json
+++ b/master/components/dashboard/manifest.json
@@ -33,12 +33,12 @@
     },
     {
       "description": "Replication Controller",
-      "url": "/replicationcontrollers/:replicationControllerId",
+      "url": "/replicationcontrollers/:namespaceId/:replicationControllerId",
       "templateUrl": "components/dashboard/views/replication.html"
     },
     {
       "description": "Service",
-      "url": "/services/:serviceId",
+      "url": "/services/:namespaceId/:serviceId",
       "templateUrl": "components/dashboard/views/service.html"
     },
     {
@@ -53,7 +53,7 @@
     },
     {
       "description": "Pod",
-      "url": "/pods/:podId",
+      "url": "/pods/:namespaceId/:podId",
       "templateUrl": "components/dashboard/views/pod.html"
     }
   ]

--- a/master/components/dashboard/views/partials/groupItem.html
+++ b/master/components/dashboard/views/partials/groupItem.html
@@ -18,9 +18,9 @@
               <!-- title -->
               <div ng-switch on='item.metadata.labels["type"]'>
                 <div class="group-name">
-                  <a ng-switch-when='pod' ng-href="#/dashboard/pods/{{ item.metadata.name }}">{{ item.metadata.name }}</a>
-                  <a ng-switch-when='service' ng-href="#/dashboard/services/{{ item.metadata.name }}">{{ item.metadata.name }}</a>
-                  <a ng-switch-when='replicationController' ng-href="#/dashboard/replicationcontrollers/{{ item.metadata.name }}">{{ item.metadata.name }}</a>
+                  <a ng-switch-when='pod' ng-href="#/dashboard/pods/{{ item.metadata.namespace }}/{{ item.metadata.name }}">{{ item.metadata.name }}</a>
+                  <a ng-switch-when='service' ng-href="#/dashboard/services/{{ item.metadata.namespace }}/{{ item.metadata.name }}">{{ item.metadata.name }}</a>
+                  <a ng-switch-when='replicationController' ng-href="#/dashboard/replicationcontrollers/{{ item.metadata.namespace }}/{{ item.metadata.name }}">{{ item.metadata.name }}</a>
                   <div ng-switch-default>{{item.metadata.name}}</div>
                 </div>
               </div>

--- a/master/components/dashboard/views/pod.html
+++ b/master/components/dashboard/views/pod.html
@@ -60,6 +60,11 @@
           </tr>
 
           <tr>
+            <td class="name">Namespace</td>
+            <td class="value">{{pod.metadata.namespace}}</td>
+          </tr>
+
+          <tr>
             <td class="name">Containers</td>
             <td class="value">
 

--- a/master/components/dashboard/views/replication.html
+++ b/master/components/dashboard/views/replication.html
@@ -56,6 +56,11 @@
           </tr>
 
           <tr>
+            <td class="name">Namespace</td>
+            <td class="value">{{replicationController.metadata.namespace}}</td>
+          </tr>
+
+          <tr>
             <td class="name">Related Pods</td>
             <td class="value">
               <div ng-show="replicationController.spec.selector && Object.keys(replicationController.spec.selector).length > 1">

--- a/master/components/dashboard/views/service.html
+++ b/master/components/dashboard/views/service.html
@@ -83,6 +83,11 @@
           </tr>
 
           <tr>
+            <td class="name">Namespace</td>
+            <td class="value">{{service.metadata.namespace}}</td>
+          </tr>
+
+          <tr>
             <td class="name">Related Pods</td>
             <td class="value">
               <div ng-show="service.spec.selector && Object.keys(service.spec.selector).length > 1">

--- a/master/shared/js/modules/services/k8sApiService.js
+++ b/master/shared/js/modules/services/k8sApiService.js
@@ -6,7 +6,7 @@
              function() {
 
                var urlBase = '';
-               var _namespace = 'default';
+               var _namespace = undefined;
 
                this.setUrlBase = function(value) { urlBase = value; };
 
@@ -28,18 +28,26 @@
 
                  api.getUrlBase = function() { return urlBase; };
 
-                 api.getNamespacedUrlBase = function() { return urlBase + '/namespaces/' + _namespace; };
+                 api.getNamespacedUrlBase = function(namespace) {
+                   var ns = '';
 
-                 api.getPods = function(query) { return _get($http, api.getNamespacedUrlBase() + '/pods', query); };
+                   if (namespace !== undefined) { ns = namespace; }
+                   else if(_namespace !== undefined) { ns = _namespace; }
+                   else { return urlBase; }
+
+                   return urlBase + '/namespaces/' + ns;
+                 };
+
+                 api.getPods = function(query, namespace) { return _get($http, api.getNamespacedUrlBase(namespace) + '/pods', query); };
 
                  api.getNodes = function(query) { return _get($http, urlBase + '/nodes', query); };
 
                  api.getMinions = api.getNodes;
 
-                 api.getServices = function(query) { return _get($http, api.getNamespacedUrlBase() + '/services', query); };
+                 api.getServices = function(query, namespace) { return _get($http, api.getNamespacedUrlBase(namespace) + '/services', query); };
 
-                 api.getReplicationControllers = function(query) {
-                   return _get($http, api.getNamespacedUrlBase() + '/replicationcontrollers', query)
+                 api.getReplicationControllers = function(query, namespace) {
+                   return _get($http, api.getNamespacedUrlBase(namespace) + '/replicationcontrollers', query);
                  };
 
                  api.getEvents = function(query) { return _get($http, api.getNamespacedUrlBase() + '/events', query); };

--- a/master/shared/js/modules/services/k8sApiService.js
+++ b/master/shared/js/modules/services/k8sApiService.js
@@ -29,13 +29,10 @@
                  api.getUrlBase = function() { return urlBase; };
 
                  api.getNamespacedUrlBase = function(namespace) {
-                   var ns = '';
-
-                   if (namespace !== undefined) { ns = namespace; }
-                   else if(_namespace !== undefined) { ns = _namespace; }
-                   else { return urlBase; }
-
-                   return urlBase + '/namespaces/' + ns;
+                   var ns = namespace || _namespace;
+                   return ns ?
+                       urlBase + '/namespaces/' + ns :
+                       urlBase;
                  };
 
                  api.getPods = function(query, namespace) { return _get($http, api.getNamespacedUrlBase(namespace) + '/pods', query); };


### PR DESCRIPTION
This fixes issue #5 by showing all namespaces by default. The k8sApi now accepts a namespace as parameter or defaults to "all". I would appreciate if someone could sanity check me, I think we need to update the gitignore to leave out the compiled pieces.
