### PR TITLE
cAdvisor node view: avoid blank view on errors

### DIFF
--- a/master/components/dashboard/js/modules/controllers/cAdvisorController.js
+++ b/master/components/dashboard/js/modules/controllers/cAdvisorController.js
@@ -26,11 +26,17 @@ app.controller('cAdvisorController', [
                 return obj.type === 'Ready';
             })[0];
 
-            return cAdvisorService.getDataForMinion(m.metadata.name, readyCondition && readyCondition.status === 'True');
-          });
+            return cAdvisorService.getDataForMinion(m.metadata.name, readyCondition && readyCondition.status === 'True')
+              .catch(function(errorData) {
+                // don't fail the whole promise chain just because one node failed
+                return null;
+              });
+        });
         $q.all(promises).then(
             function(dataArray) {
               lodash.each(dataArray, function(data, i) {
+                if (!data) return; // ignore errornous nodes
+
                 var m = res.items[i];
 
                 var maxData = maxMemCpuInfo(m.metadata.name, data.memoryData, data.cpuData, data.filesystemData);

--- a/master/components/dashboard/js/modules/controllers/cAdvisorController.js
+++ b/master/components/dashboard/js/modules/controllers/cAdvisorController.js
@@ -37,9 +37,12 @@ app.controller('cAdvisorController', [
 
                 if(m.status.addresses)
                   hostname = m.status.addresses[0].address;
+                else
+                  hostname = m.metadata.name;
 
+                cpu = m.status.capacity ? m.status.capacity.cpu : '-';
                 $scope.activeMinionDataById[m.metadata.name] =
-                    transformMemCpuInfo(data.memoryData, data.cpuData, data.filesystemData, maxData, hostname, m.status.capacity.cpu);
+                    transformMemCpuInfo(data.memoryData, data.cpuData, data.filesystemData, maxData, hostname, cpu);
               });
 
             },

--- a/master/shared/js/modules/services/cAdvisor.js
+++ b/master/shared/js/modules/services/cAdvisor.js
@@ -72,12 +72,11 @@
             deferred.resolve({
               memoryData: {
                 current: {
-                    memoryUsage: '',
-                    memoryLimit: ''
+                    memoryUsage: 0, workingMemoryUsage: 0, memoryLimit: 1.0, memoryUsageDescription: "-", memoryLimitDescription: "-"
                 },
                 historical: {}
               },
-              cpuData: { cpuPercentUsage: 0 },
+              cpuData: { cpuPercentUsage: '' },
               filesystemData: [],
               machineData: {},
               containerData: {}


### PR DESCRIPTION
Before this code the kube-ui cAdvisor view was completely blank whenever
- an error returned from accessing `/api/v1/proxy/nodes/<node>:4194/api/v1.0/machine`
- a node has no complete capacity values.

This PR adds more graceful handling of those situation. In the first case, the node is not shown in the view, in the second it is, but with empty capacity values.
